### PR TITLE
Prevent errors when is es5-fied

### DIFF
--- a/src/THREE.FBOHelper.js
+++ b/src/THREE.FBOHelper.js
@@ -6,7 +6,7 @@
 
 	var has_require = typeof require !== 'undefined'
 
-	var THREE = root.THREE || has_require && require('three')
+	var THREE = (root && root.THREE) || has_require && require('three')
 	if( !THREE )
 		throw new Error( 'FBOHelper requires three.js' )
 


### PR DESCRIPTION
This change prevents errors when the build is es5-fied by babel. (`this` is `undefined`, and this causes an error **"Can't read property `THREE` of undefined" in `root.THREE`"**)